### PR TITLE
feature(REPORT-505771): Upgraded dependent and bold reports version in desktop samples

### DIFF
--- a/UWP/Report Viewer/ConditionalParameter/ConditionalParameter.csproj
+++ b/UWP/Report Viewer/ConditionalParameter/ConditionalParameter.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/UWP/Report Viewer/ConditionalParameter/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/ConditionalParameter/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/ConditionalRowFormatting/ConditionalRowFormatting.csproj
+++ b/UWP/Report Viewer/ConditionalRowFormatting/ConditionalRowFormatting.csproj
@@ -149,7 +149,7 @@
   </ItemGroup>
   <ItemGroup>
         <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/ConditionalRowFormatting/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/ConditionalRowFormatting/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/GroupingTable/GroupingTable.csproj
+++ b/UWP/Report Viewer/GroupingTable/GroupingTable.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
         <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/GroupingTable/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/GroupingTable/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/IndicatorReport/IndicatorReport.csproj
+++ b/UWP/Report Viewer/IndicatorReport/IndicatorReport.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>IndicatorReport</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -140,7 +140,7 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
-	<EmbeddedResource Include="BoldLicense.txt" />
+    <EmbeddedResource Include="BoldLicense.txt" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -148,16 +148,16 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
   </ItemGroup>
- <ItemGroup>
-        <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+  <ItemGroup>
+    <PackageReference Include="BoldReports.UWP">
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.2</Version>
-    </PackageReference>	
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="ReportViewerPage.xaml">

--- a/UWP/Report Viewer/IndicatorReport/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/IndicatorReport/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/LineChart/LineChart.csproj
+++ b/UWP/Report Viewer/LineChart/LineChart.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/LineChart/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/LineChart/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/PivotTable/PivotTable.csproj
+++ b/UWP/Report Viewer/PivotTable/PivotTable.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/PivotTable/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/PivotTable/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/ProductCatalog/ProductCatalog.csproj
+++ b/UWP/Report Viewer/ProductCatalog/ProductCatalog.csproj
@@ -154,7 +154,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/ProductCatalog/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/ProductCatalog/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/ProductLineSales/ProductLineSales.csproj
+++ b/UWP/Report Viewer/ProductLineSales/ProductLineSales.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/ProductLineSales/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/ProductLineSales/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/QueryParameter/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/QueryParameter/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/QueryParameter/QueryParameter.csproj
+++ b/UWP/Report Viewer/QueryParameter/QueryParameter.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/RadialGauge/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/RadialGauge/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/RadialGauge/RadialGauge.csproj
+++ b/UWP/Report Viewer/RadialGauge/RadialGauge.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/ReportServer Report/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/ReportServer Report/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/ReportServer Report/ReportServer Report.csproj
+++ b/UWP/Report Viewer/ReportServer Report/ReportServer Report.csproj
@@ -131,7 +131,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/SalesDashboard/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/SalesDashboard/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/SalesDashboard/SalesDashboard.csproj
+++ b/UWP/Report Viewer/SalesDashboard/SalesDashboard.csproj
@@ -144,7 +144,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/SalesOrderDetails/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/SalesOrderDetails/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/SalesOrderDetails/SalesOrderDetails.csproj
+++ b/UWP/Report Viewer/SalesOrderDetails/SalesOrderDetails.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/TableSummaries/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/TableSummaries/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/TableSummaries/TableSummaries.csproj
+++ b/UWP/Report Viewer/TableSummaries/TableSummaries.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Viewer/TemplatedList/Properties/AssemblyInfo.cs
+++ b/UWP/Report Viewer/TemplatedList/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/UWP/Report Viewer/TemplatedList/TemplatedList.csproj
+++ b/UWP/Report Viewer/TemplatedList/TemplatedList.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Writer/OfflineExport/OfflineExport.csproj
+++ b/UWP/Report Writer/OfflineExport/OfflineExport.csproj
@@ -149,7 +149,7 @@
   </ItemGroup>
  <ItemGroup>
     <PackageReference Include="BoldReports.UWP">
-      <Version>8.1.1</Version>
+      <Version>13.1.26</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/UWP/Report Writer/OfflineExport/Properties/AssemblyInfo.cs
+++ b/UWP/Report Writer/OfflineExport/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.1.1")]
-[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyVersion("13.1.26")]
+[assembly: AssemblyFileVersion("13.1.26")]
 [assembly: ComVisible(false)]

--- a/WPF/Report Viewer/LocalRDLReport/LocalRDLReport_2017.csproj
+++ b/WPF/Report Viewer/LocalRDLReport/LocalRDLReport_2017.csproj
@@ -61,56 +61,56 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/LocalRDLReport/packages.config
+++ b/WPF/Report Viewer/LocalRDLReport/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/NetCore Integration/ViewerDemo_NETCore.csproj
+++ b/WPF/Report Viewer/NetCore Integration/ViewerDemo_NETCore.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="BoldReports.WPF" Version="8.1.1" />
+	<PackageReference Include="BoldReports.WPF" Version="13.1.26" />
 
   </ItemGroup>
 

--- a/WPF/Report Viewer/Product Showcase/Company Sales/Company Sales_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Company Sales/Company Sales_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Company Sales/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Company Sales/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Conditional Formatting/ConditionalFormatting Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Conditional Formatting/ConditionalFormatting Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Conditional Formatting/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Conditional Formatting/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Employee Sales/Employee Sales_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Employee Sales/Employee Sales_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
       <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
       <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Employee Sales/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Employee Sales/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Invoice/Invoice Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Invoice/Invoice Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
       <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
       <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Invoice/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Invoice/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Mail Merge/MailMerge Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Mail Merge/MailMerge Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Mail Merge/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Mail Merge/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Product Catalog/ProductCatalog Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Product Catalog/ProductCatalog Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
 	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
 	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Product Catalog/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Product Catalog/packages.config
@@ -2,19 +2,19 @@
 <packages>
   <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
   <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Product Line Sales/ProductLineSales Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Product Line Sales/ProductLineSales Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Product Line Sales/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Product Line Sales/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Sales Analysis/SalesAnalysis Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Sales Analysis/SalesAnalysis Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Sales Analysis/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Sales Analysis/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Sales Dashboard/SalesDashboard Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Sales Dashboard/SalesDashboard Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Sales Dashboard/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Sales Dashboard/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Sales Order/SalesOrder Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Sales Order/SalesOrder Demo_2017.csproj
@@ -57,56 +57,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Sales Order/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Sales Order/packages.config
@@ -3,19 +3,19 @@
   <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
   <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/Product Showcase/Side-By-Side Report/SideBySideReport Demo_2017.csproj
+++ b/WPF/Report Viewer/Product Showcase/Side-By-Side Report/SideBySideReport Demo_2017.csproj
@@ -57,59 +57,59 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 
 		<ExcludeAssets>runtime;compile</ExcludeAssets>
     </Reference>
 	  
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/Product Showcase/Side-By-Side Report/packages.config
+++ b/WPF/Report Viewer/Product Showcase/Side-By-Side Report/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/ReportServer Report/ReportServer_2017.csproj
+++ b/WPF/Report Viewer/ReportServer Report/ReportServer_2017.csproj
@@ -61,57 +61,57 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+    <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
     </Reference>
 	  <Reference Include="Newtonsoft.Json" />
-    <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+    <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WPF/Report Viewer/ReportServer Report/packages.config
+++ b/WPF/Report Viewer/ReportServer Report/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Viewer/WPF with WebView/BoldReportsAPI/BoldReportsAPI.csproj
+++ b/WPF/Report Viewer/WPF with WebView/BoldReportsAPI/BoldReportsAPI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BoldReports.Net.Core" Version="8.1.1" />
+    <PackageReference Include="BoldReports.Net.Core" Version="13.1.26" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.3.0" />
   </ItemGroup>
 

--- a/WPF/Report Viewer/WPF with WebView/BoldReportsWPF/wwwroot/index.html
+++ b/WPF/Report Viewer/WPF with WebView/BoldReportsWPF/wwwroot/index.html
@@ -5,15 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bold Reports Viewer</title>
     <!-- Report Viewer component styles -->
-    <link href="https://cdn.boldreports.com/8.1.1/content/v2.0/tailwind-light/bold.report-viewer.min.css" rel="stylesheet" />
+    <link href="https://cdn.boldreports.com/13.1.26/content/v2.0/tailwind-light/bold.report-viewer.min.css" rel="stylesheet" />
 
     <!-- Report Viewer component dependent script -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <script src="https://cdn.boldreports.com/8.1.1/scripts/v2.0/common/bold.reports.common.min.js"></script>
-    <script src="https://cdn.boldreports.com/8.1.1/scripts/v2.0/common/bold.reports.widgets.min.js"></script>
+    <script src="https://cdn.boldreports.com/13.1.26/scripts/v2.0/common/bold.reports.common.min.js"></script>
+    <script src="https://cdn.boldreports.com/13.1.26/scripts/v2.0/common/bold.reports.widgets.min.js"></script>
 
     <!-- Report Viewer component script -->
-    <script src="https://cdn.boldreports.com/8.1.1/scripts/v2.0/bold.report-viewer.min.js"></script>
+    <script src="https://cdn.boldreports.com/13.1.26/scripts/v2.0/bold.report-viewer.min.js"></script>
 </head>
 <body>
     <div id="viewer-container" style="width: 100%; height: 100vh;"></div>

--- a/WPF/Report Writer/NetCore Integration/WriterDemo_NETCore.csproj
+++ b/WPF/Report Writer/NetCore Integration/WriterDemo_NETCore.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="BoldReports.WPF" Version="8.1.1" />
+	<PackageReference Include="BoldReports.WPF" Version="13.1.26" />
   </ItemGroup>
 </Project>

--- a/WPF/Report Writer/Product Showcase/Company Sales/CompanySales_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Company Sales/CompanySales_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-	  <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-		  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+	  <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+		  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	  </Reference>
-	  <Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	  <Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	  <Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	  <Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	  <Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	  <Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	  <Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	  <Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	  <Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	  <Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-		  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	  <Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+		  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	  </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Company Sales/packages.config
+++ b/WPF/Report Writer/Product Showcase/Company Sales/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Conditional Formatting/ConditionalFormatting_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Conditional Formatting/ConditionalFormatting_2017.csproj
@@ -39,57 +39,57 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
 	<Reference Include="Newtonsoft.Json" />
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Conditional Formatting/packages.config
+++ b/WPF/Report Writer/Product Showcase/Conditional Formatting/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Employee Sales/EmployeeSales_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Employee Sales/EmployeeSales_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Employee Sales/packages.config
+++ b/WPF/Report Writer/Product Showcase/Employee Sales/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Mail Merge/MailMerge_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Mail Merge/MailMerge_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Mail Merge/packages.config
+++ b/WPF/Report Writer/Product Showcase/Mail Merge/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Product Line Sales/ProductLineSales_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Product Line Sales/ProductLineSales_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Product Line Sales/packages.config
+++ b/WPF/Report Writer/Product Showcase/Product Line Sales/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Sales Analysis/SalesAnalysis_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Sales Analysis/SalesAnalysis_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Sales Analysis/packages.config
+++ b/WPF/Report Writer/Product Showcase/Sales Analysis/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Sales Dashboard/SalesDashboard_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Sales Dashboard/SalesDashboard_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Sales Dashboard/packages.config
+++ b/WPF/Report Writer/Product Showcase/Sales Dashboard/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Sales Order/SalesOrder_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Sales Order/SalesOrder_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Sales Order/packages.config
+++ b/WPF/Report Writer/Product Showcase/Sales Order/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>

--- a/WPF/Report Writer/Product Showcase/Side-By-Side Report/SideBySideReport_2017.csproj
+++ b/WPF/Report Writer/Product Showcase/Side-By-Side Report/SideBySideReport_2017.csproj
@@ -39,56 +39,56 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bold.Licensing, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Bold.Licensing.8.1.1\lib\net462\Bold.Licensing.dll</HintPath>
+    <Reference Include="Bold.Licensing, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Bold.Licensing.13.1.26\lib\net462\Bold.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="BoldReports.WPF, Version=8.1462.1.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\BoldReports.WPF.8.1.1\lib\net462\BoldReports.WPF.dll</HintPath>
+	<Reference Include="BoldReports.WPF, Version=13.1462.26.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\BoldReports.WPF.13.1.26\lib\net462\BoldReports.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Chart.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.28.2.3\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Chart.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Chart.WPF.Classic.32.1.19\lib\net462\Syncfusion.Chart.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Compression.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Compression.Base.28.2.3\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Compression.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Compression.Base.32.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.DocIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.DocIO.Wpf.28.2.3\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.DocIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.DocIO.Wpf.32.1.19\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Gauge.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Gauge.WPF.28.2.3\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Gauge.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Gauge.WPF.32.1.19\lib\net462\Syncfusion.Gauge.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Grid.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Grid.WPF.28.2.3\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Grid.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Grid.WPF.32.1.19\lib\net462\Syncfusion.Grid.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.GridCommon.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.GridCommon.Wpf.28.2.3\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.GridCommon.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.GridCommon.Wpf.32.1.19\lib\net462\Syncfusion.GridCommon.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Licensing, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Licensing.28.2.3\lib\net462\Syncfusion.Licensing.dll</HintPath>
+	<Reference Include="Syncfusion.Licensing, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Licensing.32.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Linq.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Linq.Base.28.2.3\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Linq.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Linq.Base.32.1.19\lib\net462\Syncfusion.Linq.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.OfficeChart.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.OfficeChart.Base.28.2.3\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+	<Reference Include="Syncfusion.OfficeChart.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.OfficeChart.Base.32.1.19\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Pdf.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Pdf.Wpf.28.2.3\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Pdf.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Pdf.Wpf.32.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Presentation.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Presentation.Wpf.28.2.3\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
+	<Reference Include="Syncfusion.Presentation.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Presentation.Wpf.32.1.19\lib\net462\Syncfusion.Presentation.Base.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.SfMaps.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.SfMaps.WPF.28.2.3\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.SfMaps.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.SfMaps.WPF.32.1.19\lib\net462\Syncfusion.SfMaps.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.28.2.3\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.32.1.19\lib\net462\Syncfusion.Shared.WPF.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.28.2.3\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
+	<Reference Include="Syncfusion.Shared.WPF.Classic, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.Shared.WPF.Classic.32.1.19\lib\net462\Syncfusion.Shared.WPF.Classic.dll</HintPath>
 	</Reference>
-	<Reference Include="Syncfusion.XlsIO.Base, Version=28.2462.3.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-	  <HintPath>packages\Syncfusion.XlsIO.Wpf.28.2.3\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
+	<Reference Include="Syncfusion.XlsIO.Base, Version=32.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+	  <HintPath>packages\Syncfusion.XlsIO.Wpf.32.1.19\lib\net462\Syncfusion.XlsIO.Base.dll</HintPath>
 	</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/WPF/Report Writer/Product Showcase/Side-By-Side Report/packages.config
+++ b/WPF/Report Writer/Product Showcase/Side-By-Side Report/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bold.Licensing" version="8.1.1" targetFramework="net462" />
+  <package id="Bold.Licensing" version="13.1.26" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="BoldReports.WPF" version="8.1.1" targetFramework="net462" />
-  <package id="Syncfusion.Chart.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Compression.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Gauge.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Grid.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.GridCommon.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Linq.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Pdf.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Presentation.Wpf" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.SfMaps.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.Shared.WPF.Classic" version="28.2.3" targetFramework="net462" />
-  <package id="Syncfusion.XlsIO.Wpf" version="28.2.3" targetFramework="net462" />
+  <package id="BoldReports.WPF" version="13.1.26" targetFramework="net462" />
+  <package id="Syncfusion.Chart.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Gauge.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Grid.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.GridCommon.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Linq.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Presentation.Wpf" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.SfMaps.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.Shared.WPF.Classic" version="32.1.19" targetFramework="net462" />
+  <package id="Syncfusion.XlsIO.Wpf" version="32.1.19" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
<table>
<tr>
<td>
Feature Description:
</td>
<td>
Resolved the UWP report server sample throwing authentication error
</td>
</tr>
<tr>
<td>
Analysis:
</td>
<td>
Resolved the UWP report server sample throwing authentication error
</td>
</tr>
<tr>
<td>
Reason for not identifying earlier:
</td>
<td>
No, this is new changes.
</td>
</tr>
<tr>
<td>
Is it a breaking issue?
</td>
<td>
yes
</td>
</tr>
<tr>
<td>
Solution description:
</td>
<td>
Upgraded dependent and bold reports version in desktop samples
</td>
</tr>
<tr>
<td>
Areas affected and ensured:
</td>
<td>
Yes
</td>
</tr>
<tr>
<td>
Test cases:
</td>
<td>
Upgraded dependent and bold reports version in desktop samples
</td>
</tr>
 <tr>
        <td>Test bed sample locations</td>
        <td>The sample location details are available in the same task - https://dev.azure.com/Syncfusion-Bold/Bold%20Reports/_workitems/edit/505771</td>
    </tr>
</table>